### PR TITLE
feat: integrate git files for all folders in workspace

### DIFF
--- a/lua/telescope/_extensions/workwork.lua
+++ b/lua/telescope/_extensions/workwork.lua
@@ -6,6 +6,7 @@ return require("telescope").register_extension({
 	end,
 	exports = {
 		select = integration.select,
-		workspace_files = integration.workspace_files,
+		files = integration.workspace_files,
+		git_files = integration.git_files,
 	},
 })


### PR DESCRIPTION
For now, telescope doesnt support chaining finders (https://github.com/nvim-telescope/telescope.nvim/issues/213). So, instead I run a plenary Job for each folder inside the workspace, take its results and then display it. 