### PR TITLE
feat: support telescope git files

### DIFF
--- a/lua/telescope/_extensions/workwork.lua
+++ b/lua/telescope/_extensions/workwork.lua
@@ -8,5 +8,6 @@ return require("telescope").register_extension({
 	exports = {
 		select = integration.select,
 		files = integration.files,
+		git_files = integration.git_files,
 	},
 })


### PR DESCRIPTION
For now, telescope doesnt support chaining finders (https://github.com/nvim-telescope/telescope.nvim/issues/213). So, instead I run a plenary Job for each folder inside the workspace, take its results and then display it.